### PR TITLE
fix: Redirect oomusou.io to old-oomusou.goodjack.tw

### DIFF
--- a/source/_posts/genesis.md
+++ b/source/_posts/genesis.md
@@ -573,7 +573,7 @@ markdown:
 - [手把手教你使用Hexo + Github Pages搭建个人独立博客 | 令狐葱@前端笔记](https://linghucong.js.org/2016/04/15/2016-04-15-hexo-github-pages-blog/)
 - [Documentation | Hexo](https://hexo.io/docs/)
 - [NexT 使用文档](http://theme-next.iissnan.com/getting-started.html)
-- [如何使用Hexo寫草稿? | 點燈坊](http://oomusou.io/hexo/hexo-draft/)
+- [如何使用Hexo寫草稿? | 點燈坊](https://old-oomusou.goodjack.tw/hexo/draft/)
 
 [marked]: https://github.com/hexojs/hexo-renderer-marked
 [Markdown-it]: https://github.com/celsomiranda/hexo-renderer-markdown-it


### PR DESCRIPTION
舊的 oomusou.io 文章已經轉移至 old-oomusou.goodjack.tw